### PR TITLE
Use system CA certs

### DIFF
--- a/ldap.go
+++ b/ldap.go
@@ -42,9 +42,13 @@ func (l *ldapEnv) connectTLS() (*ldap.Conn, error) {
 		return nil, err
 	}
 
-	certs := *x509.NewCertPool()
+	certs, err := x509.SystemCertPool()
+	if err != nil {
+		logging(err)
+		return nil, err
+	}
 	tlsConfig := &tls.Config{
-		RootCAs: &certs,
+		RootCAs: certs,
 	}
 
 	if !isAddr(host) {


### PR DESCRIPTION
Use system certificate authorities certificates instead of an empty pool to avoid certificate verification errors on well-known CAs

This fixes #7 